### PR TITLE
chore(friends): fix webring URLs for Sapphic Webring

### DIFF
--- a/src/pages/friends.astro
+++ b/src/pages/friends.astro
@@ -62,13 +62,13 @@ const description = "Awesome people I know from the interwebs";
       </div>
 
       <div class="grid lg:grid-cols-6 grid-cols-3 h-20 border border-card rounded shadow-md bg-bg-lighter items-center text-center justify-center">
-        <a class="h-full flex items-center justify-center border-r border-r-card group" href="https://ring.sapphic.moe/isabelroses/left" aria-label="previous sapphic webring">
+        <a class="h-full flex items-center justify-center border-r border-r-card group" href="https://ring.sapphic.moe/isabelroses/previous" aria-label="previous sapphic webring">
           <Icon name="fa6-solid:arrow-left" class="icon inline-block translate-x-0 group-hover:-translate-x-1 transition-transform ease-in-out duration-200"/>
         </a>
 
         <a class="h-full flex items-center justify-center lg:col-span-4" href="https://ring.sapphic.moe/" aria-label="aberystwyth webring">Sapphic webring</a>
 
-        <a class="h-full flex items-center justify-center border-l border-l-card group" href="https://ring.sapphic.moe/isabelroses/right" aria-label="next sapphic webring">
+        <a class="h-full flex items-center justify-center border-l border-l-card group" href="https://ring.sapphic.moe/isabelroses/next" aria-label="next sapphic webring">
           <Icon name="fa6-solid:arrow-right" class="icon inline-block translate-x-0 group-hover:translate-x-1 transition-transform ease-in-out duration-200" />
         </a>
       </div>


### PR DESCRIPTION
The `left` and `right` designations do not exist, so I fixed them to use the correct paths instead.


