### PR TITLE
fix: blog clipping

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,7 +32,7 @@
       content: none;
     }
 
-    @apply max-w-[80vw] md:max-w-[75ch] lg:max-w-[85ch] mx-auto;
+    @apply max-w-[min(80vw,100%)] md:max-w-[min(75ch,100%)] lg:max-w-[min(85ch,100%)] mx-auto;
   }
 
   .smallcaps {


### PR DESCRIPTION
before and after

<img width="348" height="744" alt="image" src="https://github.com/user-attachments/assets/02de4151-2fb1-40b1-902e-6b89a60f504c" />

<img width="134" height="541" alt="image" src="https://github.com/user-attachments/assets/961ce79a-f1d4-4eaf-8eee-a62784917373" />

Also the link on your "my website" project is confusing — it shows the github icon but links to your own website. you should prolly fix that